### PR TITLE
Set nullable context to disable for C# wrapper

### DIFF
--- a/addons/better-terrain/BetterTerrain.cs
+++ b/addons/better-terrain/BetterTerrain.cs
@@ -1,6 +1,8 @@
 using Godot;
 using Godot.Collections;
 
+#nullable disable
+
 /*
 
 This is a lightweight wrapper for Better Terrain in C#.


### PR DESCRIPTION
I use nullable contexts on my project, and with the changes made on #60 I started to get warnings the other way around. The warning is `CS8625: Cannot convert null literal to non-nullable reference type`.

While the nullable context can be set for a file, if none is defined then the project setting is used. With the changes I made on #39, those warnings were solved for me, but other warnings were introduced for projects that didn't enable this feature (hence, #59 was created).

Although I believe everyone should enable nullable contexts when creating a new project (it's really handy in avoiding null reference exceptions!), Godot creates C# projects with this feature disabled. You have to change the project setting manually in order to use it, and I understand that the majority of users will not do this.

What I'm proposing, then, is to explicitly set the nullable context to `disable` at the C# wrapper file. That way everyone should be happy, the file setting will override the project setting and no one will get any warnings about nullability anymore. People using nullable contexts will have to be aware that better-terrain does not, but this is something you will have to do with all external libraries you use anyway, so it's not really a problem.

Also added the missing newline character at the end of the file.